### PR TITLE
Better timestamps (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out
 
 .vscode/
 .bsp/
+save/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ JS entry point:
 - Use `scalafix` somewhat-often. Check out e.g. `mill debate.jvm.fix`.
  - TODO make this run automatically
  - TODO add the todo -> github issue thing
+- For a nice loop in case metals is slow, check out `mill -w -i debate.jvm.run  --port 8080 --save save`
+
+### A Simple Loop
+
+- Start the server
+- Load the site and join a new debate as a facilitator.
+  - You can change roles between the participants and the judge.
+  - TODO can we make this easier- load an example debate?
+  - TODO should the example be shared between the debaters?
+- You can also see what observers see by clicking `Observer`
 
 ## Background
 

--- a/build.sc
+++ b/build.sc
@@ -1,4 +1,4 @@
-import $ivy.`com.goyeau::mill-scalafix::0.2.11`
+import $ivy.`com.goyeau::mill-scalafix::0.2.11` // TODO refactor where this is
 import com.goyeau.mill.scalafix.ScalafixModule
 import mill._, mill.scalalib._, mill.scalalib.publish._, mill.scalajslib._
 import mill.scalalib.scalafmt._
@@ -54,8 +54,9 @@ trait CommonModule extends ScalaModule with ScalafmtModule with ScalafixModule {
     // most of the FP dependencies are pulled in by JJM
     ivy"org.julianmichael::jjm-core::$jjmVersion",
     ivy"org.julianmichael::jjm-io::$jjmVersion",
-    ivy"io.suzaku::boopickle::$boopickleVersion"
+    ivy"io.suzaku::boopickle::$boopickleVersion",
     // ivy"org.typelevel::kittens::$kittensVersion",
+    ivy"io.github.cquiroz::scala-java-time::2.0.0" // TODO probably not the right version
   )
 }
 

--- a/debate/src-js/App.scala
+++ b/debate/src-js/App.scala
@@ -638,6 +638,26 @@ object App {
         .toVdomArray
     }
 
+    def speechToHTML(speech: DebateSpeech) = {
+      val roleString = speech.speaker.role.toString
+      <.div(S.speechHeader)(
+        speech.speaker.name,
+        s" ($roleString) ",
+        <.span(S.speechTimestamp)(
+          minSecTime(speech.timestamp - setup.startTime)
+        ).when(speech.timestamp > 0)
+      )
+    }
+
+    def quoteToHTML(span: ESpan) = {
+      <.span(
+        <.span(S.quoteText)(
+          breakNewlines(ling.Text.renderSpan(setup.sourceMaterial, span))
+        ),
+        <.span(S.quoteCitation)(s" (${span.begin}–${span.end})")
+      )
+    }
+
     def makeSimultaneousSpeechesHtml(
         speeches: Map[Int, DebateSpeech],
         speechIndex: Int
@@ -646,28 +666,12 @@ object App {
         ^.key := s"speech-$speechIndex",
         speeches.toVector.sortBy(_._1).toVdomArray {
           case (debaterIndex, speech) =>
-            val roleString = speech.speaker.role.toString
-
             <.div(S.speechBox, S.answerBg(debaterIndex))(
               ^.key := s"speech-$speechIndex-$debaterIndex",
-              <.div(S.speechHeader)(
-                speech.speaker.name,
-                s" ($roleString) ",
-                <.span(S.speechTimestamp)(
-                  minSecTime(speech.timestamp - setup.startTime)
-                ).when(speech.timestamp > 0)
-              ),
+              speechToHTML(speech),
               speech.content.toVdomArray {
-                case SpeechSegment.Text(text) => makeSimpleVdomFromText(text)
-                case SpeechSegment.Quote(span) =>
-                  <.span(
-                    <.span(S.quoteText)(
-                      breakNewlines(
-                        ling.Text.renderSpan(setup.sourceMaterial, span)
-                      )
-                    ),
-                    <.span(S.quoteCitation)(s" (${span.begin}–${span.end})")
-                  )
+                case SpeechSegment.Text(text)  => makeSimpleVdomFromText(text)
+                case SpeechSegment.Quote(span) => quoteToHTML(span)
               }
             )
         }
@@ -679,25 +683,12 @@ object App {
         style: TagMod,
         speechIndex: Int
     ) = {
-      val roleString = speech.speaker.role.toString
       <.div(S.speechBox, style)(
         ^.key := s"speech-$speechIndex",
-        <.div(S.speechHeader)(
-          speech.speaker.name,
-          s" ($roleString) ",
-          <.span(S.speechTimestamp)(
-            minSecTime(speech.timestamp - setup.startTime)
-          ).when(speech.timestamp > 0)
-        ),
+        speechToHTML(speech),
         speech.content.toVdomArray {
-          case SpeechSegment.Text(text) => makeSimpleVdomFromText(text)
-          case SpeechSegment.Quote(span) =>
-            <.span(
-              <.span(S.quoteText)(
-                breakNewlines(ling.Text.renderSpan(setup.sourceMaterial, span))
-              ),
-              <.span(S.quoteCitation)(s" (${span.begin}–${span.end})")
-            )
+          case SpeechSegment.Text(text)  => makeSimpleVdomFromText(text)
+          case SpeechSegment.Quote(span) => quoteToHTML(span)
         }
       )
     }

--- a/debate/src-js/App.scala
+++ b/debate/src-js/App.scala
@@ -36,6 +36,8 @@ import scala.util.Try
 
 import io.circe.generic.JsonCodec
 
+import java.time.{Instant, ZoneId}
+
 // @js.native
 // @JSGlobal("showdown.Converter")
 // class Converter extends js.Object {
@@ -653,7 +655,18 @@ object App {
         speech.speaker.name,
         s" ($roleString) ",
         <.span(S.speechTimestamp)(
-          minSecTime(speech.timestamp - setup.startTime)
+          minSecTime(speech.timestamp - setup.startTime),
+          " into the debate at ",
+            {
+              val base = {
+                Instant
+                  .ofEpochMilli(speech.timestamp)
+                  // TODO this should perhaps display it in the client's timezone
+                  .atZone(ZoneId.of("Z")) // see "time zones" on http://cquiroz.github.io/scala-java-time/
+                  .toLocalTime
+                  .toString }
+            base + " UTC"
+            }
         ).when(speech.timestamp > 0)
       )
     }

--- a/debate/src-js/App.scala
+++ b/debate/src-js/App.scala
@@ -1,5 +1,7 @@
 package debate
 
+import annotation.unused
+
 import jjm.implicits._
 
 import scalajs.js
@@ -638,6 +640,13 @@ object App {
         .toVdomArray
     }
 
+    def minSecTime(millis: Long): String = {
+      val secs = millis / 1000
+      val mins = secs / 60
+      val secsRem = secs % 60
+      s"${mins}m ${secsRem}s"
+    }
+
     def speechToHTML(speech: DebateSpeech) = {
       val roleString = speech.speaker.role.toString
       <.div(S.speechHeader)(
@@ -775,7 +784,7 @@ object App {
 
           def speechInputPanel(
               submit: Callback,
-              cmdEnterToSubmit: Boolean = true
+              @unused cmdEnterToSubmit: Boolean = true
           ) = {
             <.div(S.speechInputPanel)(
               V.LiveTextArea.String.mod(
@@ -1181,10 +1190,10 @@ object App {
     }
   }
 
-  class Backend(scope: BackendScope[Unit, Unit]) {
+  class Backend(@unused scope: BackendScope[Unit, Unit]) {
 
     /** Main render method. */
-    def render(props: Unit, state: Unit) = {
+    def render(@unused props: Unit, @unused state: Unit) = {
       <.div(S.app)(
         LocalConnectionSpecOpt.make(None) { connectionSpecOpt =>
           connectionSpecOpt.value match {

--- a/debate/src-js/SpanSelection2.scala
+++ b/debate/src-js/SpanSelection2.scala
@@ -1,5 +1,7 @@
 package debate
 
+import annotation.unused
+
 import jjm.ling.ISpan
 
 import japgolly.scalajs.react.vdom.html_<^._
@@ -21,9 +23,6 @@ object SpanSelection2 {
     // in order for the lenses to actually compile. something is messed up
     // private[this] val indexSet: (Index => Selecting => Selecting) =
     //   (i: Index) => (s: Selecting) => s.copy(index = i)
-    (a: Int) => (s: Selecting) => s.copy(anchor = a)
-    (e: Int) => (s: Selecting) => s.copy(endpoint = e)
-    // val index = Lens[Selecting, Index](_.index)(i => s => s.copy(index = i))
     val anchor = Lens[Selecting, Int](_.anchor)(a => s => s.copy(anchor = a))
     val endpoint =
       Lens[Selecting, Int](_.endpoint)(e => s => s.copy(endpoint = e))
@@ -60,7 +59,7 @@ object SpanSelection2 {
 
   class Backend(scope: BackendScope[Props, Status]) {
 
-    def hover(props: Props, state: Status)(endpoint: Int) =
+    def hover(@unused props: Props, @unused state: Status)(endpoint: Int) =
       scope.modState {
         case Selecting(anchor, _) => Selecting(anchor, endpoint)
         case x                    => x

--- a/debate/src-jvm/Serve.scala
+++ b/debate/src-jvm/Serve.scala
@@ -26,7 +26,7 @@ import java.nio.file.{Path => NIOPath}
   */
 object Serve
     extends CommandIOApp(
-      name = "mill -i debate.jvm.runMain debate.Serve",
+      name = "mill -i debate.jvm.run",
       header = "Serve the live chat app."
     ) {
 

--- a/debate/src/package.scala
+++ b/debate/src/package.scala
@@ -65,11 +65,4 @@ package object debate extends PackagePlatformExtensions {
       .filter(_.nonEmpty)
     res
   }
-
-  def minSecTime(millis: Long): String = {
-    val secs = millis / 1000
-    val mins = secs / 60
-    val secsRem = secs % 60
-    s"${mins}m ${secsRem}s"
-  }
 }


### PR DESCRIPTION
Addresses #5. There's a pretty big limitation in that timestamps are just printed in UTC. If we want to add the local time zone of the server, this link is relevant: http://cquiroz.github.io/scala-java-time/ (see "time zones"). (There's a link to that in the code.)

Also includes some cleanup with `@unused`.