### PR TITLE
debaters.json missing debug info

### DIFF
--- a/debate/src-jvm/Serve.scala
+++ b/debate/src-jvm/Serve.scala
@@ -216,7 +216,7 @@ object Serve
         .recoverWith { case e: Throwable =>
           IO {
             println("Error reading debaters JSON. Initializing to empty JSON.")
-            e.printStackTrace()
+            println(s"--->\tError message: ${e.getMessage()}")
             Set.empty[String] // start with empty if none already exists
           }
         }


### PR DESCRIPTION
Print formatted message instead of stack trace when debaters.json is missing.

Resolves: https://github.com/julianmichael/debate/issues/35