### PR TITLE
Analytics v1

### DIFF
--- a/scripts/wrong_judgements.py
+++ b/scripts/wrong_judgements.py
@@ -1,0 +1,57 @@
+import os
+import pandas as pd  # type: ignore
+
+data_dir = os.environ.get("DATA_DIR", default="save")
+
+global debates
+global sessions
+global turns
+debates = pd.read_csv(
+    os.path.join(data_dir, "official/summaries/debates.csv"), keep_default_na=True
+)
+debates["Start time"] = pd.to_datetime(debates["Start time"], unit="ms")
+# only include debates after the given time
+debates = debates[debates["Start time"] > pd.to_datetime("10/02/23", format="%d/%m/%y")]
+debates["Final probability incorrect"] = 1 - debates["Final probability correct"]
+debates["End time"] = pd.to_datetime(debates["End time"], unit="ms")
+sessions = pd.read_csv(
+    os.path.join(data_dir, "official/summaries/sessions.csv"), keep_default_na=True
+)
+# filter sessions to only the included debates
+sessions = sessions.merge(debates[["Room name"]], how="inner", on="Room name")
+
+# turns = pd.read_csv(
+#     os.path.join(data_dir, "official/summaries/turns.csv"), keep_default_na=True
+# )
+# turns["Room start time"] = pd.to_datetime(turns["Room start time"], unit="ms")
+# # filter turns to only the included debates
+# turns = turns.merge(debates[["Room name"]], how="inner", on="Room name")
+
+
+judgements = sessions[sessions["Final probability correct"].notnull()]
+judgements = judgements.dropna(axis=1, how="all")
+judgements = judgements.drop(columns=["Is turn", "Is over"])
+
+
+wrong_judgements = judgements[judgements["Final probability correct"] < 0.5]
+
+wrong_judgements_info = wrong_judgements.merge(
+    debates[
+        [
+            "Room name",
+            "Is offline",
+            "Honest debater",
+            "Dishonest debater",
+            "Speed annotator accuracy",
+            "End time",
+        ]
+    ],
+    how="left",
+    on="Room name",
+)
+
+wrong_judgements_info = wrong_judgements_info.sort_values(by=["Room name", "End time"])
+
+wrong_judgements_info.to_csv(
+    os.path.join(data_dir, "official/summaries/wrong_judgements.csv"), index=False
+)

--- a/vis/server.py
+++ b/vis/server.py
@@ -179,6 +179,7 @@ def outcomes_by_field(source, rowEncoding = None):
         color = alt.Color(
             'Final probability correct (with imputation):Q',
             scale=alt.Scale(scheme='redblue', domain=[0.0, 1.0]),
+            title='Final probability correct'
         ),
         order=alt.Order(
             'Final probability correct (dist from half):Q',

--- a/vis/server.py
+++ b/vis/server.py
@@ -48,10 +48,8 @@ def read_data():
     debates["End time"] = pd.to_datetime(debates["End time"], unit="ms")
     # only include debates for a given time
     debates = debates[
-        debates["Start time"] > pd.to_datetime("10/02/23", format="%d/%m/%y")
-    ]
-    debates = debates[
-        debates["End time"] < pd.to_datetime("26/05/23", format="%d/%m/%y")
+        debates["Start time"] > pd.to_datetime("10/02/23", format="%d/%m/%y") #&
+        #debates["End time"] < pd.to_datetime("26/05/23", format="%d/%m/%y")
     ]
     debates["Final probability incorrect"] = 1 - debates["Final probability correct"]
     sessions = pd.read_csv(os.path.join(data_dir, "official/summaries/sessions.csv"), keep_default_na=True)

--- a/vis/server.py
+++ b/vis/server.py
@@ -91,7 +91,7 @@ read_data()
 # The offline debates were 50% correct, and the live debates were 60% correct." (Copilot, 2023)
 
 
-# def an_overview_of_counts():  # TODO: un-average offline
+# def an_overview_of_counts():  # TO maybe DO: un-average offline
 #     # debates["Final probability correct (live and mean of offline)"] = debates.apply(
 #     #     lambda row: row["Final probability correct"]
 #     #     if row["Is offline"] == False

--- a/vis/server.py
+++ b/vis/server.py
@@ -297,10 +297,6 @@ def accuracy_by_judge_setting():
         else row['Role'],
         axis=1,
     )
-    # source['Role'] + source['Is offline'].map({True: ' (no live judge)', False: ''})
-
-    # print('==========')
-    # print(source[source['roleWithOffline'] == 'Judge (no live judge)'])
 
     rowEncoding = alt.Row(field ='roleWithOffline', type='N', title='Role')
     yEncoding = alt.Y(field ='roleWithOffline', type='N', title='Role')
@@ -322,6 +318,34 @@ def accuracy_by_judge_setting():
         ).properties(title="Accuracy by Judge Setting"),
         accuracy_by_field(accuracy_source).properties(
             title="Aggregate Accuracy (All Settings)"
+        )
+    ).resolve_scale(x = 'independent')
+
+def accuracy_by_judge():
+
+    source = sessions
+    source = source[source['Role'].isin(['Judge', 'Offline Judge'])]
+
+    rowEncoding = alt.Row(field ='Participant', type='N', title='Participant')
+    yEncoding = alt.Y(field ='Participant', type='N', title='Participant')
+
+    # outcomes_source = source
+    accuracy_source = source[source['Final probability correct'].notna()]
+
+    return alt.vconcat(
+        # outcomes_by_field(
+        #     outcomes_source,
+        #     rowEncoding = rowEncoding
+        # ).properties(title="Outcomes by Judge Setting"),
+        # outcomes_by_field(outcomes_source).properties(
+        #     title="Aggregate Outcomes (All Settings)"
+        # ),
+        accuracy_by_field(
+            accuracy_source,
+            yEncoding = yEncoding
+        ).properties(title="Accuracy by Judge"),
+        accuracy_by_field(accuracy_source).properties(
+            title="Aggregate Accuracy (All Judges)"
         )
     ).resolve_scale(x = 'independent')
 
@@ -1221,6 +1245,7 @@ def debates_completed_per_week():
 all_graph_specifications = {
     "Main_results:_An_overview_of_counts": an_overview_of_counts,
     "Main_results:_Accuracy_by_judge_setting": accuracy_by_judge_setting,
+    "Results:_Accuracy_by_judge": accuracy_by_judge,
     "Results:_Distribution_of_final_probability_correct,_live_vs_offline_debates": final_probability_correct_distribution_live_vs_offline_debates,
     "Results:_Evidence_by_rounds": evidence_by_rounds,
     "Results:_Evidence_by_rounds_and_participant": evidence_by_rounds_and_participant,

--- a/vis/server.py
+++ b/vis/server.py
@@ -91,51 +91,51 @@ read_data()
 # The offline debates were 50% correct, and the live debates were 60% correct." (Copilot, 2023)
 
 
-def an_overview_of_counts():  # TODO: un-average offline
-    # debates["Final probability correct (live and mean of offline)"] = debates.apply(
-    #     lambda row: row["Final probability correct"]
-    #     if row["Is offline"] == False
-    #     else row["Average offline probability correct"],
-    #     axis=1,
-    # )
-    bins = [0, 0.491, 0.509, 1]
-    labels = ["0-49%", "0.5", "51-100%"]
-    sessions["Final probability correct bins"] = pd.cut(
-        sessions["Final probability correct"],
-        bins=bins,
-        labels=labels,
-    )
-    counts_bar = (
-        alt.Chart(sessions).transform_filter(
-            alt.FieldOneOfPredicate(field='Role', oneOf=["Judge", "Offline Judge"])
-        )
-        .mark_bar()
-        .encode(
-            x=alt.X("count()", stack="zero", title="Number of judgements"),
-            y=alt.Y("Final probability correct bins:O"),
-            color=alt.Color(
-                "Final probability correct bins:O",
-                sort="descending",
-                scale=alt.Scale(range=[correctColor, "white", incorrectColor, nullColor]),
-            ),
-            row=alt.Row(
-                "Role:N",
-                # header=alt.Header(
-                #     title="Debates categorized by correctness, setup, and status",
-                #     titleFontSize=18,
-                #     titleFontWeight="bold",
-                #     titleOrient="top",
-                #     labelExpr='datum.value ? "Offline (averaged)" : "Live"',
-                #     labelOrient="top",
-                #     labelAnchor="start",
-                #     labelFontSize=14,
-                #     labelFontWeight="bold",
-                # ),
-            ),
-            tooltip=["count()", "Final probability correct bins:O"],
-        )
-    )
-    return counts_bar.properties(width=fullWidth - 100, height=fullHeight / 4)
+# def an_overview_of_counts():  # TODO: un-average offline
+#     # debates["Final probability correct (live and mean of offline)"] = debates.apply(
+#     #     lambda row: row["Final probability correct"]
+#     #     if row["Is offline"] == False
+#     #     else row["Average offline probability correct"],
+#     #     axis=1,
+#     # )
+#     bins = [0, 0.491, 0.509, 1]
+#     labels = ["0-49%", "0.5", "51-100%"]
+#     sessions["Final probability correct bins"] = pd.cut(
+#         sessions["Final probability correct"],
+#         bins=bins,
+#         labels=labels,
+#     )
+#     counts_bar = (
+#         alt.Chart(sessions).transform_filter(
+#             alt.FieldOneOfPredicate(field='Role', oneOf=["Judge", "Offline Judge"])
+#         )
+#         .mark_bar()
+#         .encode(
+#             x=alt.X("count()", stack="zero", title="Number of judgements"),
+#             y=alt.Y("Final probability correct bins:O"),
+#             color=alt.Color(
+#                 "Final probability correct bins:O",
+#                 sort="descending",
+#                 scale=alt.Scale(range=[correctColor, "white", incorrectColor, nullColor]),
+#             ),
+#             row=alt.Row(
+#                 "Role:N",
+#                 # header=alt.Header(
+#                 #     title="Debates categorized by correctness, setup, and status",
+#                 #     titleFontSize=18,
+#                 #     titleFontWeight="bold",
+#                 #     titleOrient="top",
+#                 #     labelExpr='datum.value ? "Offline (averaged)" : "Live"',
+#                 #     labelOrient="top",
+#                 #     labelAnchor="start",
+#                 #     labelFontSize=14,
+#                 #     labelFontWeight="bold",
+#                 # ),
+#             ),
+#             tooltip=["count()", "Final probability correct bins:O"],
+#         )
+#     )
+#     return counts_bar.properties(width=fullWidth - 100, height=fullHeight / 4)
 
 def outcomes_by_field(source, rowEncoding = None):
 
@@ -701,115 +701,115 @@ def final_probability_correct_by_judge_experience_and_participant():  # TODO: ad
     )
 
 
-def final_probability_correct_by_num_judge_rounds():
-    source = sessions.merge(
-        debates[
-            [
-                "Room name",
-                "Judge",
-                "Number of continues",
-                "Final probability correct",
-                "Speed annotator accuracy",
-            ]
-        ],
-        how="left",
-        on="Room name",
-    )
-    print(source.describe())
-    source = source[source["Role"].str.startswith("Debater")]
-    source = source.groupby("Room name").mean().reset_index()
-    print(source.groupby(["Room name"]).mean())
-    base = (
-        alt.Chart(source)
-        .mark_circle(size=60, color=aggColor)
-        .encode(
-            x="Number of continues:Q",
-            y="Final probability correct:Q",
-            tooltip=["Room name"],
-        )
-        .properties(width=fullWidth)
-        # .transform_filter(datum["Number of continues"])
-    )
-    mean = (
-        alt.Chart(source)
-        .mark_line()
-        .transform_aggregate(
-            mean_prob="mean(Final probability correct)", groupby=["Number of continues"]
-        )
-        .encode(
-            x=alt.X("Number of continues:Q", axis=alt.Axis(values=[1, 2, 3, 4, 5, 6])),
-            y="mean_prob:Q",
-            # tooltip=["Room name"],
-            color=alt.value(aggColor),
-        )
-        .properties(width=fullWidth)
-        # .transform_filter(datum["Number of continues"])
-    )
-    err = (
-        alt.Chart(source)
-        .mark_errorband(extent="ci")
-        .encode(
-            x="Number of continues:Q",
-            y="Final probability correct:Q",
-            color=alt.value(aggColor),
-        )
-        .properties(width=fullWidth)
-    )
-    return (
-        base
-        + err
-        + mean
-    )
+# def final_probability_correct_by_num_judge_rounds():
+#     source = sessions.merge(
+#         debates[
+#             [
+#                 "Room name",
+#                 "Judge",
+#                 "Number of continues",
+#                 "Final probability correct",
+#                 "Speed annotator accuracy",
+#             ]
+#         ],
+#         how="left",
+#         on="Room name",
+#     )
+#     print(source.describe())
+#     source = source[source["Role"].str.startswith("Debater")]
+#     source = source.groupby("Room name").mean().reset_index()
+#     print(source.groupby(["Room name"]).mean())
+#     base = (
+#         alt.Chart(source)
+#         .mark_circle(size=60, color=aggColor)
+#         .encode(
+#             x="Number of continues:Q",
+#             y="Final probability correct:Q",
+#             tooltip=["Room name"],
+#         )
+#         .properties(width=fullWidth)
+#         # .transform_filter(datum["Number of continues"])
+#     )
+#     mean = (
+#         alt.Chart(source)
+#         .mark_line()
+#         .transform_aggregate(
+#             mean_prob="mean(Final probability correct)", groupby=["Number of continues"]
+#         )
+#         .encode(
+#             x=alt.X("Number of continues:Q", axis=alt.Axis(values=[1, 2, 3, 4, 5, 6])),
+#             y="mean_prob:Q",
+#             # tooltip=["Room name"],
+#             color=alt.value(aggColor),
+#         )
+#         .properties(width=fullWidth)
+#         # .transform_filter(datum["Number of continues"])
+#     )
+#     err = (
+#         alt.Chart(source)
+#         .mark_errorband(extent="ci")
+#         .encode(
+#             x="Number of continues:Q",
+#             y="Final probability correct:Q",
+#             color=alt.value(aggColor),
+#         )
+#         .properties(width=fullWidth)
+#     )
+#     return (
+#         base
+#         + err
+#         + mean
+#     )
 
-def final_probability_correct_by_num_judge_continues():
-    source = sessions.merge(
-        debates[
-            [
-                "Room name",
-                "Final probability correct"
-            ]
-        ],
-        how="left",
-        on="Room name",
-    )
-    base = (
-        alt.Chart(source)
-        .mark_circle(size=60, color=aggColor)
-        .encode(
-            x="Number of judge continues:Q",
-            y="Final probability correct:Q",
-            tooltip=["Room name"],
-        )
-        .properties(width=fullWidth)
-    )
-    mean = (
-        alt.Chart(source)
-        .mark_line()
-        .transform_aggregate(
-            mean_prob="mean(Final probability correct)", groupby=["Number of judge continues"]
-        )
-        .encode(
-            x=alt.X("Number of judge continues:Q", axis=alt.Axis(values=[0, 1, 2, 3, 4, 5, 6])),
-            y="mean_prob:Q",
-            color=alt.value(aggColor),
-        )
-        .properties(width=fullWidth)
-    )
-    err = (
-        alt.Chart(turns)
-        .mark_errorband(extent="ci")
-        .encode(
-            x="Number of judge continues:Q",
-            y="Final probability correct:Q",
-            color=alt.value(aggColor),
-        )
-        .properties(width=fullWidth)
-    )
-    return (
-        base
-        + err
-        + mean
-    )
+# def final_probability_correct_by_num_judge_continues():
+#     source = sessions.merge(
+#         debates[
+#             [
+#                 "Room name",
+#                 "Final probability correct"
+#             ]
+#         ],
+#         how="left",
+#         on="Room name",
+#     )
+#     base = (
+#         alt.Chart(source)
+#         .mark_circle(size=60, color=aggColor)
+#         .encode(
+#             x="Number of judge continues:Q",
+#             y="Final probability correct:Q",
+#             tooltip=["Room name"],
+#         )
+#         .properties(width=fullWidth)
+#     )
+#     mean = (
+#         alt.Chart(source)
+#         .mark_line()
+#         .transform_aggregate(
+#             mean_prob="mean(Final probability correct)", groupby=["Number of judge continues"]
+#         )
+#         .encode(
+#             x=alt.X("Number of judge continues:Q", axis=alt.Axis(values=[0, 1, 2, 3, 4, 5, 6])),
+#             y="mean_prob:Q",
+#             color=alt.value(aggColor),
+#         )
+#         .properties(width=fullWidth)
+#     )
+#     err = (
+#         alt.Chart(turns)
+#         .mark_errorband(extent="ci")
+#         .encode(
+#             x="Number of judge continues:Q",
+#             y="Final probability correct:Q",
+#             color=alt.value(aggColor),
+#         )
+#         .properties(width=fullWidth)
+#     )
+#     return (
+#         base
+#         + err
+#         + mean
+#     )
 
 def make_mean_lines_with_scatter( # TODO: add question text...
         base_chart,
@@ -1090,43 +1090,6 @@ def turns_to_complete_by_participant():
     )
 
 
-def debater_turns_by_week():
-    debates["End week"] = debates["End time"].apply(lambda x: x.week)
-
-    def convert_time(x):
-        start_date = datetime.datetime.strptime(f"{x.year}-{x.week}-1", "%Y-%W-%w")
-        end_date = start_date + pd.Timedelta(days=6)
-        return f'{start_date.strftime("%b%d")}|{end_date.strftime("%b%d")}'
-
-    debates["End week label"] = debates["End time"].apply(convert_time)
-    source = sessions.merge(debates, how="left", on="Room name")
-    source["Role"] = source["Role"].map(
-        lambda x: "Debater" if x.startswith("Debater") else x
-    )
-    return (
-        alt.Chart(source)
-        .mark_bar()
-        .encode(
-            x=alt.X(
-                "End week label:O",
-                sort=alt.EncodingSortField(  # TODO: fix, doesn't seem sorted
-                    field="End week", order="ascending"
-                ),
-            ),
-            y=alt.Y("count()"),
-            color=alt.Color("Role:O"),
-        )
-        .transform_filter(
-            datum["Status"]
-            != "complete" & datum["Is turn"]
-            == True & datum["Judge"]
-            != None
-        )
-        .properties(width=200)
-        .facet(facet="Judge:N", columns=4, spacing=10)
-    )
-
-
 def debater_pairings_by_role():
     return (
         alt.Chart(debates)
@@ -1137,10 +1100,6 @@ def debater_pairings_by_role():
             color="count():Q",
         )
     )
-
-
-def debater_pairings_by_person():  # TODO Instead of having them in separate items on the dropdown menu, hv multiple tweakers for the same viewed data?
-    return
 
 
 def participant_by_current_workload():
@@ -1163,36 +1122,6 @@ def participant_by_current_workload():
             column=alt.Column("Role:O"),
         )
         .transform_filter(datum["Is over_x"] == False)
-        .properties(width=200)
-    )
-
-
-def participant_by_past_workloads():
-    source = sessions.merge(debates, how="left", on="Room name")
-    source["Role"] = source["Role"].map(
-        lambda x: "Debater" if x.startswith("Debater") else x
-    )
-    source["End date"] = source["End time"] - pd.to_timedelta(6, unit="d")
-    source_by_week = (
-        source.groupby(["Participant", pd.Grouper(key="End date", freq="W-MON")])
-        .sum()
-        .reset_index()
-        .sort_values("End date")
-    )
-
-    return (
-        alt.Chart(source_by_week)
-        .mark_bar()
-        .encode(
-            x=alt.X("count()"),
-            y=alt.Y(
-                "Participant:O",
-                sort=alt.EncodingSortField(op="count", order="descending"),
-            ),
-            color=alt.Color("End date:O"),
-            column=alt.Column("End date:O"),
-        )
-        .transform_filter(datum["Status"] == "complete")
         .properties(width=200)
     )
 
@@ -1268,7 +1197,7 @@ def debates_completed_per_week():
 # Keys must be valid URL paths. I'm not URL-encoding them.
 # Underscores will be displayed as spaces in the debate webapp analytics pane.
 all_graph_specifications = {
-    "Main_results:_An_overview_of_counts": an_overview_of_counts,
+    #"Main_results:_An_overview_of_counts": an_overview_of_counts,
     "Main_results:_Accuracy_by_judge_setting": accuracy_by_judge_setting,
     "Results:_Win_rates_by_participant": win_rates_by_participant,
     "Results:_Distribution_of_final_probability_correct,_live_vs_offline_debates": final_probability_correct_distribution_live_vs_offline_debates,
@@ -1278,21 +1207,17 @@ all_graph_specifications = {
     "Results:_Final_probability_correct_by_judge": final_probability_correct_by_judge,
     "Results:_Final_probability_correct_by_judge_experience": final_probability_correct_by_judge_experience,
     "Results:_Final_probability_correct_by_judge_experience_and_participant": final_probability_correct_by_judge_experience_and_participant,
-    "Results:_Final_probability_correct_by_num_judge_rounds": final_probability_correct_by_num_judge_rounds,
-    "Results:_Final_probability_correct_by_num_judge_continues": final_probability_correct_by_num_judge_continues,
+    # "Results:_Final_probability_correct_by_num_judge_rounds": final_probability_correct_by_num_judge_rounds,
+    # "Results:_Final_probability_correct_by_num_judge_continues": final_probability_correct_by_num_judge_continues,
     "Results:_Intermediate_probability_correct_by_num_debate_rounds": intermediate_probability_correct_by_num_debate_rounds,
     "Results_(Metadata):_Final_probability_correct_by_speed_annotator_accuracy": final_probability_correct_by_speed_annotator_accuracy,
     "Results_(Feedback):_Final_probability_correct_by_question_subjectivity": final_probability_correct_by_question_subjectivity,
     "Results_(Feedback):_Final_probability_correct_by_information_progress": final_probability_correct_by_information_progress,
-    # "Results:_Live_debates_accuracy_by_date": live_debates_accuracy_by_date,
     "Track:_Anonymity": anonymity,
     "Track:_Debates_completed_per_week": debates_completed_per_week,
-    "Track:_Debater_turns_by_week": debater_turns_by_week,
     "Track:_Participant_by_current_workload": participant_by_current_workload,
-    # "Track:_Participant_by_past_workload": participant_by_past_workload,
     "Track:_Turns_to_complete_by_participant": turns_to_complete_by_participant,
     "Track:_Debater_pairings_by_role": debater_pairings_by_role,
-    # "Track:_Debater_pairings_by_person": debater_pairings_by_person,
     "Track:_Judge_pairings": judge_pairings,
     "Track:_Num_rounds_per_debate": num_rounds_per_debate,
 }

--- a/vis/server.py
+++ b/vis/server.py
@@ -31,7 +31,7 @@ data_dir = os.environ.get("DATA_DIR", default="save")
 # set graphic parameters
 correctColor = "green"
 incorrectColor = "crimson"
-nullColor = "grey"
+nullColor = "lightgrey"
 onlineColor = "orange"
 offlineColor = "blue"
 aggColor = "black"
@@ -180,7 +180,7 @@ def outcomes_by_field(source, rowEncoding = None):
         x=alt.X('count():Q'),
         color = alt.Color(
             'Final probability correct (with imputation):Q',
-            scale=alt.Scale(scheme='redblue', domain=[0.0, 1.0]),
+            scale=alt.Scale(range=[incorrectColor, nullColor, correctColor], domain=[0.0, 1.0]),
             title='Final probability correct'
         ),
         order=alt.Order(
@@ -226,7 +226,7 @@ def accuracy_by_field(source, yEncoding = None, invert = False):
             ),
             scale=alt.Scale(domain=[0.0, 1.0])
         ),
-        color=alt.Color('Final probability correct:Q', scale=alt.Scale(scheme='redblue', domain=[0.0, 1.0])),
+        color=alt.Color('Final probability correct:Q', scale=alt.Scale(range=[incorrectColor, nullColor, correctColor], domain=[0.0, 1.0])),
         order=alt.Order(
             f'Final probability correct:Q',
             sort='descending' if not invert else 'ascending'
@@ -240,7 +240,7 @@ def accuracy_by_field(source, yEncoding = None, invert = False):
         ]
     ).properties(width=fullWidth - 200)
 
-    prop_color = 'green'
+    prop_color = aggColor
     # rule_thickness = 1.0
     # err_thickness = 1.0
     point_size = 25.0

--- a/vis/server.py
+++ b/vis/server.py
@@ -703,118 +703,7 @@ def final_probability_correct_by_judge_experience_and_participant():  # TODO: ad
         width=fullWidth, height=fullHeight
     )
 
-
-# def final_probability_correct_by_num_judge_rounds():
-#     source = sessions.merge(
-#         debates[
-#             [
-#                 "Room name",
-#                 "Judge",
-#                 "Number of continues",
-#                 "Final probability correct",
-#                 "Speed annotator accuracy",
-#             ]
-#         ],
-#         how="left",
-#         on="Room name",
-#     )
-#     print(source.describe())
-#     source = source[source["Role"].str.startswith("Debater")]
-#     source = source.groupby("Room name").mean().reset_index()
-#     print(source.groupby(["Room name"]).mean())
-#     base = (
-#         alt.Chart(source)
-#         .mark_circle(size=60, color=aggColor)
-#         .encode(
-#             x="Number of continues:Q",
-#             y="Final probability correct:Q",
-#             tooltip=["Room name"],
-#         )
-#         .properties(width=fullWidth)
-#         # .transform_filter(datum["Number of continues"])
-#     )
-#     mean = (
-#         alt.Chart(source)
-#         .mark_line()
-#         .transform_aggregate(
-#             mean_prob="mean(Final probability correct)", groupby=["Number of continues"]
-#         )
-#         .encode(
-#             x=alt.X("Number of continues:Q", axis=alt.Axis(values=[1, 2, 3, 4, 5, 6])),
-#             y="mean_prob:Q",
-#             # tooltip=["Room name"],
-#             color=alt.value(aggColor),
-#         )
-#         .properties(width=fullWidth)
-#         # .transform_filter(datum["Number of continues"])
-#     )
-#     err = (
-#         alt.Chart(source)
-#         .mark_errorband(extent="ci")
-#         .encode(
-#             x="Number of continues:Q",
-#             y="Final probability correct:Q",
-#             color=alt.value(aggColor),
-#         )
-#         .properties(width=fullWidth)
-#     )
-#     return (
-#         base
-#         + err
-#         + mean
-#     )
-
-# def final_probability_correct_by_num_judge_continues():
-#     source = sessions.merge(
-#         debates[
-#             [
-#                 "Room name",
-#                 "Final probability correct"
-#             ]
-#         ],
-#         how="left",
-#         on="Room name",
-#     )
-#     base = (
-#         alt.Chart(source)
-#         .mark_circle(size=60, color=aggColor)
-#         .encode(
-#             x="Number of judge continues:Q",
-#             y="Final probability correct:Q",
-#             tooltip=["Room name"],
-#         )
-#         .properties(width=fullWidth)
-#     )
-#     mean = (
-#         alt.Chart(source)
-#         .mark_line()
-#         .transform_aggregate(
-#             mean_prob="mean(Final probability correct)", groupby=["Number of judge continues"]
-#         )
-#         .encode(
-#             x=alt.X("Number of judge continues:Q", axis=alt.Axis(values=[0, 1, 2, 3, 4, 5, 6])),
-#             y="mean_prob:Q",
-#             color=alt.value(aggColor),
-#         )
-#         .properties(width=fullWidth)
-#     )
-#     err = (
-#         alt.Chart(turns)
-#         .mark_errorband(extent="ci")
-#         .encode(
-#             x="Number of judge continues:Q",
-#             y="Final probability correct:Q",
-#             color=alt.value(aggColor),
-#         )
-#         .properties(width=fullWidth)
-#     )
-#     return (
-#         base
-#         + err
-#         + mean
-#     )
-
-def make_mean_lines_with_scatter( # TODO: add question text...
+def make_mean_lines_with_scatter(
         base_chart,
         x,
         y,
@@ -859,6 +748,26 @@ def make_mean_lines_with_scatter( # TODO: add question text...
         )
     )
     return (points + err + mean)
+
+def final_probability_correct_by_num_judge_continues():
+    source = sessions.merge(debates[["Room name", "Is offline"]], how="left", on="Room name")
+    base = (
+        alt.Chart(source)
+        .transform_filter((datum['Role'] == 'Judge') | (datum['Role'] == 'Offline Judge'))
+        .transform_calculate(roleWithOffline = "datum['Role'] + ' ' + (datum['Is offline'] ? '(no live judge)' : '')")
+        .encode(
+            x=alt.X("Number of judge continues:Q", axis = alt.Axis(tickMinStep=1), title="Number of judge continues"),
+            color=alt.Color('roleWithOffline:N', legend=alt.Legend(title="Role", orient="bottom")),
+        )
+        .properties(width=fullWidth)
+    )
+    return make_mean_lines_with_scatter(
+        base,
+        x = "Number of judge continues",
+        y = "Final probability correct",
+        series = 'roleWithOffline',
+        tooltip = ["Room name", 'Participant']
+    )
 
 def intermediate_probability_correct_by_num_debate_rounds():
     source = turns.merge(
@@ -1210,8 +1119,7 @@ all_graph_specifications = {
     "Results:_Final_probability_correct_by_judge": final_probability_correct_by_judge,
     "Results:_Final_probability_correct_by_judge_experience": final_probability_correct_by_judge_experience,
     "Results:_Final_probability_correct_by_judge_experience_and_participant": final_probability_correct_by_judge_experience_and_participant,
-    # "Results:_Final_probability_correct_by_num_judge_rounds": final_probability_correct_by_num_judge_rounds,
-    # "Results:_Final_probability_correct_by_num_judge_continues": final_probability_correct_by_num_judge_continues,
+    "Results:_Final_probability_correct_by_num_judge_continues": final_probability_correct_by_num_judge_continues,
     "Results:_Intermediate_probability_correct_by_num_debate_rounds": intermediate_probability_correct_by_num_debate_rounds,
     "Results_(Metadata):_Final_probability_correct_by_speed_annotator_accuracy": final_probability_correct_by_speed_annotator_accuracy,
     "Results_(Feedback):_Final_probability_correct_by_question_subjectivity": final_probability_correct_by_question_subjectivity,


### PR DESCRIPTION
* fix buggy final prob judge rounds, made to match inter prob debate rounds
* deleting or commenting out some old graphs
There shouldn't be any more buggy graphs and I'm going to focus on making static graphs for the paper vs updating the interface for now. Will still do in a .py script in repo
* wrong_judgements.py, what I used to generate the .csv to categorize failure modes for the wrong judgements (with their counterparts)